### PR TITLE
fix: remove `:automergeMinor` default preset

### DIFF
--- a/personal.json
+++ b/personal.json
@@ -3,7 +3,6 @@
   "description": "Include personal config presets",
   "extends": [
     ":assignee(@marcusrbrown)",
-    ":automergeMinor",
     ":prConcurrentLimitNone",
     ":pinAllExceptPeerDependencies"
   ],


### PR DESCRIPTION
The @brfra-me presets already include this preset.