### PR TITLE
chore: clean up `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
-auto-install-peers = true
-ignore-workspace-root-check = true
 save-exact = true
 shell-emulator = true
-strict-peer-dependencies = true
+strict-peer-dependencies = false


### PR DESCRIPTION
Disable `strict-peer-dependencies` and remove unused options