### PR TITLE
chore(renovate): clean up self-config and scripts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   description: ['Use the config preset for the @marcusrbrown/renovate-config repository'],
-  extends: [
-    'local>marcusrbrown/renovate-config',
-    'github>sanity-io/renovate-config:semantic-commit-type',
-    ':assignAndReview(fro-bot)',
-  ],
+  extends: ['local>marcusrbrown/renovate-config', 'github>sanity-io/renovate-config:semantic-commit-type'],
   packageRules: [
     {
       matchPackageNames: [

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -46,6 +46,5 @@ jobs:
           'archived-repository.json',
           'default.json',
           'onboarding.json',
-          'personal.json',
         ]
       print-config: ${{ inputs.print-config || false }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "type": "module",
   "main": "default.json",
   "scripts": {
-    "bootstrap": "pnpm install --prefer-offline --loglevel warn",
+    "bootstrap": "pnpm install --no-strict-peer-dependencies --prefer-offline",
     "lint": "eslint",
     "fix": "eslint --fix",
     "prepare": "simple-git-hooks"
@@ -29,7 +29,7 @@
   },
   "lint-staged": {
     "*.{js,json,jsx,md,toml,ts,tsx,yml,yaml}": [
-      "eslint --fix"
+      "pnpm run fix"
     ]
   },
   "prettier": "@bfra.me/prettier-config/120-proof",


### PR DESCRIPTION
- remove `:assignAndReview(fro-bot)` from `.github/renovate.json5`
- drop `personal.json` from config-file inputs in `.github/workflows/renovate.yaml`
- update `bootstrap` to use `pnpm install --no-strict-peer-dependencies --prefer-offline`
- run lint-staged fixes through `pnpm run fix` for consistent local tooling