### PR TITLE
build(renovate): track and bump upstream preset refs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,10 +2,25 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   description: ['Use the config preset for the @marcusrbrown/renovate-config repository'],
   extends: ['local>marcusrbrown/renovate-config', 'github>sanity-io/renovate-config:semantic-commit-type'],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: ['Update `bfra-me/renovate-config` preset from GitHub releases.'],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'bfra-me/renovate-config',
+      managerFilePatterns: ['/^default\\.json$/'],
+      matchStrings: [
+        '[\'"]github>bfra-me/renovate-config#(?<currentValue>[^\'" \\n\\(]+)',
+        '[\'"]github>bfra-me/renovate-config/[^#]+#(?<currentValue>[^\'" \\n]+)',
+        '[\'"]github>bfra-me/renovate-config:[^#]+#(?<currentValue>[^\'" \\n]+)',
+      ],
+    },
+  ],
   packageRules: [
     {
       matchPackageNames: [
         '@semantic-release/{/,}**',
+        'bfra-me/renovate-config',
         'conventional-changelog-conventionalcommits',
         'semantic-release',
         'semantic-release-export-data',

--- a/default.json
+++ b/default.json
@@ -2,8 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Use the default config preset for all @marcusrbrown repositories.",
   "extends": [
-    "github>bfra-me/renovate-config#5.1.0",
-    "github>bfra-me/renovate-config:fro-bot.json5#5.1.0",
+    "github>bfra-me/renovate-config#5.2.0",
+    "github>bfra-me/renovate-config:fro-bot.json5#5.2.0",
+    "github>bfra-me/renovate-config:renovate-config.json5(marcusrbrown/renovate-config)#5.2.0",
     ":assignAndReview(marcusrbrown)",
     ":disableRateLimiting",
     ":preserveSemverRanges",


### PR DESCRIPTION
- bump `bfra-me/renovate-config` preset references in `default.json` from `5.1.0` to `5.2.0`
- add `renovate-config.json5(marcusrbrown/renovate-config)` preset extension pinned to `5.2.0`
- add regex `customManagers` in `.github/renovate.json5` to detect and update pinned `bfra-me/renovate-config` versions in `default.json`
- extend semantic commit typing rules to include `bfra-me/renovate-config` updates as `build`